### PR TITLE
Fix humphd/brackets#129 - HintHinter Gutter too large, and bubble looks odd in Large Text Mode

### DIFF
--- a/errorDisplay.js
+++ b/errorDisplay.js
@@ -42,9 +42,8 @@ define(function (require, exports, module) {
 
     //Function that adds a button on the gutter (on given line nubmer) next to the line numbers
     function showButton(line){
-        var errorMarker = document.createElement("div");
-        errorMarker.className = "errorButton errorText";
-        errorMarker.innerHTML = "!";
+        var errorMarker = document.createElement("i");
+        errorMarker.className = "fa fa-exclamation-circle fa-lg icon";
 
         getCodeMirror().setGutterMarker(line, "errors", errorMarker);
 

--- a/main.less
+++ b/main.less
@@ -1,32 +1,25 @@
+/*Font family for errorPanel*/
+@fontFamily: Helvetica, Arial, "Meiryo UI", "ＭＳ Ｐゴシック", "MS PGothic", sans-serif;
+
 .errorHighlight {
     background-color: #EDC5C5;
 }
 
-.errorButton {
-    margin: 1px;
-    background-color: #FF0000;
-}
-
-.errorText {
-    padding-left: 3px;
-    padding-right: 3px;
-    font-weight: bold;
-    color: black;
-    border-radius: 100%;
-}
-
-.errorButton.errorText {
-    color: white;
+.icon {
+    color: #FF0000;
+    margin-left: 2px;
 }
 
 .errorPanel {
     padding-left: 20px;
     background-color: #EDC5C5;
     color: black;
+    font-family: @fontFamily;
 }
 
 .errorPanel h4 {
     font-weight: bold;
+    font-family: @fontFamily;
 }
 
 .tooltipsy {
@@ -38,10 +31,15 @@
 }
 
 .errors {
-    width: 15px;
+    width: 25px;
     cursor: pointer;
 }
 
 .gutterCursor {
     cursor: pointer;
+}
+
+.CodeMirror .CodeMirror-linenumber {
+    padding-right: 0px;
+    padding-left: 0px;
 }


### PR DESCRIPTION
Fixes https://github.com/humphd/brackets/issues/129.
Changes look like this

Small

![screen shot 2015-03-25 at 2 48 07 pm](https://cloud.githubusercontent.com/assets/9154982/6832818/3b45df82-d2ff-11e4-9352-64ff2798dc56.png)

Medium

![screen shot 2015-03-25 at 2 40 46 pm](https://cloud.githubusercontent.com/assets/9154982/6832826/4485d822-d2ff-11e4-883f-feec4441f8e1.png)

Large

![screen shot 2015-03-25 at 2 49 05 pm](https://cloud.githubusercontent.com/assets/9154982/6832834/48d6283c-d2ff-11e4-8749-e4bb267a2a6f.png)
